### PR TITLE
Fix: ambiguous macro "log" with the logarithmic math function

### DIFF
--- a/include/flogging.h
+++ b/include/flogging.h
@@ -9,14 +9,14 @@
 #define LOG_LEVEL_DEBUG_DEF 5 
 #define LOG_LEVEL_TRACE_DEF 6 
 
-#define log(level,format) if(logp(level))write(logu,format)trim(logl(level,__FILE__,__LINE__))//" ",
+#define log_macro(level,format) if(logp(level))write(logu,format)trim(logl(level,__FILE__,__LINE__))//" ",
 #define log_root(level,format) if(logp(level,0))write(logu,format)trim(logl(level,__FILE__,__LINE__))//" ",
 
 /* First four log levels */
-#define log_fatal(format) log(LOG_LEVEL_FATAL_DEF,format)
-#define log_error(format) log(LOG_LEVEL_ERROR_DEF,format)
-#define log_warn(format) log(LOG_LEVEL_WARN_DEF,format)
-#define log_info(format) log(LOG_LEVEL_INFO_DEF,format)
+#define log_fatal(format) log_macro(LOG_LEVEL_FATAL_DEF,format)
+#define log_error(format) log_macro(LOG_LEVEL_ERROR_DEF,format)
+#define log_warn(format) log_macro(LOG_LEVEL_WARN_DEF,format)
+#define log_info(format) log_macro(LOG_LEVEL_INFO_DEF,format)
 
 #define log_fatal_root(format) log_root(LOG_LEVEL_FATAL_DEF,format)
 #define log_error_root(format) log_root(LOG_LEVEL_ERROR_DEF,format)
@@ -27,12 +27,12 @@
 #define log_debug(format) if(.false.)write(logu,format)
 #define log_debug_root(format) if(.false.)write(logu,format)
 #else
-#define log_debug(format) log(LOG_LEVEL_DEBUG_DEF,format)
+#define log_debug(format) log_macro(LOG_LEVEL_DEBUG_DEF,format)
 #define log_debug_root(format) log_root(LOG_LEVEL_DEBUG_DEF,format)
 #endif
 
 #ifdef ENABLE_LOG_TRACE
-#define log_trace(format) log(LOG_LEVEL_TRACE_DEF,format)
+#define log_trace(format) log_macro(LOG_LEVEL_TRACE_DEF,format)
 #define log_trace_root(format) log_root(LOG_LEVEL_TRACE_DEF,format)
 #else
 #define log_trace(format) if(.false.)write(logu,format)


### PR DESCRIPTION
When the "flogging.h" is included in a fortran source file, the log function will be ambiguous. This pull request fix this issue.